### PR TITLE
Feature/arkiv oppdatert wsdl

### DIFF
--- a/fetch-updated-wsdls.sh
+++ b/fetch-updated-wsdls.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+function update() {
+  mkdir -p tmp
+  wget -O tmp/wsdl.zip $2
+  unzip -d "$1/src/main/wsdl" tmp/wsdl.zip
+  rm tmp/wsdl.zip
+  rm -r tmp
+}
+update "arkiv" "http://maven.adeo.no/nexus/content/groups/public/no/nav/esb/nav/nav-tjeneste-arkiv/1.2.1/nav-tjeneste-arkiv-1.2.1-wsdlif.zip"

--- a/pen-esb-wsclient-legacy/pom.xml
+++ b/pen-esb-wsclient-legacy/pom.xml
@@ -251,6 +251,11 @@
                                     <wsdl>${basedir}/src/main/resources/wsdl/no/nav/virksomhet/tjenester/person/v2/Binding.wsdl</wsdl>
                                 </wsdlOption>
 
+                                <!-- PEN Arkiv v1 -->
+                                <wsdlOption>
+                                    <wsdl>${basedir}/src/main/resources/wsdl/nav-tjeneste-arkiv_ArkivWSEXP.wsdl</wsdl>
+                                </wsdlOption>
+
                                 <!-- PEN Journal v2 -->
                                 <wsdlOption>
                                     <wsdl>${basedir}/src/main/resources/wsdl/no/nav/virksomhet/tjenester/arkiv/journal/v2/Binding.wsdl</wsdl>

--- a/pen-esb-wsclient-legacy/src/main/resources/wsdl/nav-tjeneste-arkiv_ArkivWSEXP.wsdl
+++ b/pen-esb-wsclient-legacy/src/main/resources/wsdl/nav-tjeneste-arkiv_ArkivWSEXP.wsdl
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="ArkivWSEXP_ArkivHttp_Service" targetNamespace="http://nav.no/virksomhet/tjenester/arkiv/v1/Binding" xmlns:Port_0="http://nav.no/virksomhet/tjenester/arkiv/v1" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:this="http://nav.no/virksomhet/tjenester/arkiv/v1/Binding">
+  <wsdl:import namespace="http://nav.no/virksomhet/tjenester/arkiv/v1" location="no/nav/virksomhet/tjenester/arkiv/arkiv.wsdl">
+    </wsdl:import>
+  <wsdl:binding name="ArkivWSEXP_ArkivHttpBinding" type="Port_0:Arkiv">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="bestillBrev">
+      <soap:operation soapAction=""/>
+      <wsdl:input>
+        <soap:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap:body use="literal"/>
+      </wsdl:output>
+      <wsdl:fault name="adresseIkkeRegistrert">
+        <soap:fault name="adresseIkkeRegistrert" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="manglerObligatoriskInput">
+        <soap:fault name="manglerObligatoriskInput" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="opprettelseJournalpostFeilet">
+        <soap:fault name="opprettelseJournalpostFeilet" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="henteBrevdataFeilet">
+        <soap:fault name="henteBrevdataFeilet" use="literal"/>
+      </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="ArkivWSEXP_ArkivHttpService">
+    <wsdl:port name="ArkivWSEXP_ArkivHttpPort" binding="this:ArkivWSEXP_ArkivHttpBinding">
+      <soap:address location="http://localhost:9080/nav-tjeneste-arkiv_v1Web/sca/ArkivWSEXP"/>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>

--- a/pen-esb-wsclient-legacy/src/main/resources/wsdl/nav-tjeneste-arkiv_ArkivWSEXP.wsdl
+++ b/pen-esb-wsclient-legacy/src/main/resources/wsdl/nav-tjeneste-arkiv_ArkivWSEXP.wsdl
@@ -12,17 +12,17 @@
       <wsdl:output>
         <soap:body use="literal"/>
       </wsdl:output>
-      <wsdl:fault name="adresseIkkeRegistrert">
-        <soap:fault name="adresseIkkeRegistrert" use="literal"/>
-      </wsdl:fault>
       <wsdl:fault name="manglerObligatoriskInput">
         <soap:fault name="manglerObligatoriskInput" use="literal"/>
+      </wsdl:fault>
+      <wsdl:fault name="henteBrevdataFeilet">
+        <soap:fault name="henteBrevdataFeilet" use="literal"/>
       </wsdl:fault>
       <wsdl:fault name="opprettelseJournalpostFeilet">
         <soap:fault name="opprettelseJournalpostFeilet" use="literal"/>
       </wsdl:fault>
-      <wsdl:fault name="henteBrevdataFeilet">
-        <soap:fault name="henteBrevdataFeilet" use="literal"/>
+      <wsdl:fault name="adresseIkkeRegistrert">
+        <soap:fault name="adresseIkkeRegistrert" use="literal"/>
       </wsdl:fault>
     </wsdl:operation>
   </wsdl:binding>

--- a/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/arkiv/arkiv.wsdl
+++ b/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/arkiv/arkiv.wsdl
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:tns="http://nav.no/virksomhet/tjenester/arkiv/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="arkiv" targetNamespace="http://nav.no/virksomhet/tjenester/arkiv/v1">
+  <wsdl:types>
+    <xsd:schema xmlns:feil="http://nav.no/virksomhet/tjenester/arkiv/feil/v1" xmlns:meldinger="http://nav.no/virksomhet/tjenester/arkiv/meldinger/v1" targetNamespace="http://nav.no/virksomhet/tjenester/arkiv/v1">
+      <xsd:import namespace="http://nav.no/virksomhet/tjenester/arkiv/feil/v1" schemaLocation="feil/feil.xsd" />
+      <xsd:import namespace="http://nav.no/virksomhet/tjenester/arkiv/meldinger/v1" schemaLocation="meldinger/meldinger.xsd" />
+      <xsd:element name="bestillBrev">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="request" type="meldinger:BestillBrevRequest" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="bestillBrevResponse">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element minOccurs="0" name="response" type="meldinger:BestillBrevResponse" />
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="bestillBrevadresseIkkeRegistrert" type="feil:AdresseIkkeRegistrert" />
+      <xsd:element name="bestillBrevhenteBrevdataFeilet" type="feil:HenteBrevdataFeilet" />
+      <xsd:element name="bestillBrevmanglerObligatoriskInput" type="feil:ManglerObligatoriskInput" />
+      <xsd:element name="bestillBrevopprettelseJournalpostFeilet" type="feil:OpprettelseJournalpostFeilet" />
+    </xsd:schema>
+  </wsdl:types>
+  <wsdl:message name="bestillBrev_opprettelseJournalpostFeilet">
+    <wsdl:part name="opprettelseJournalpostFeilet" element="tns:bestillBrevopprettelseJournalpostFeilet">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="bestillBrevRequest">
+    <wsdl:part name="parameters" element="tns:bestillBrev">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="bestillBrev_manglerObligatoriskInput">
+    <wsdl:part name="manglerObligatoriskInput" element="tns:bestillBrevmanglerObligatoriskInput">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="bestillBrevResponse">
+    <wsdl:part name="parameters" element="tns:bestillBrevResponse">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="bestillBrev_henteBrevdataFeilet">
+    <wsdl:part name="henteBrevdataFeilet" element="tns:bestillBrevhenteBrevdataFeilet">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:message name="bestillBrev_adresseIkkeRegistrert">
+    <wsdl:part name="adresseIkkeRegistrert" element="tns:bestillBrevadresseIkkeRegistrert">
+    </wsdl:part>
+  </wsdl:message>
+  <wsdl:portType name="Arkiv">
+    <wsdl:operation name="bestillBrev">
+<wsdl:documentation>&lt;p&gt;Prosessen for brevproduksjon består av følgende steg:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;p&gt;&lt;b&gt;Hente data fra baksystemer&lt;/b&gt;: Prosessen henter ut data fra et gitt sett av baksystemer basert på innparametrene (primært brevgruppe). Innparametrene identifiserer blant annet brevtype og mottager, og dataene samles opp i en datastruktur som korresponderer til det som sendes videre til brevproduksjonsmodulen.&lt;/p&gt;&lt;/li&gt;&lt;/ul&gt;&lt;ul&gt;&lt;li&gt;&lt;p&gt;&lt;b&gt;Journalføre: &lt;/b&gt;Når data er hentet ut, gjøres det en midlertidig journalføring mot JOARK. På bakgrunn av innparametere og innhentede data kalles JOARK og et journalpostnummer returneres. Dette blir brukt både i den videre brevproduksjonen og returnes til det kallende system som referanse til brevet.&lt;/p&gt;&lt;/li&gt;&lt;/ul&gt;&lt;ul&gt;&lt;li&gt;&lt;p&gt;&lt;b&gt;Sende brevdata til Brevserver&lt;/b&gt;: Når data er hentet ut og brevet journalført blir det generert en XML med brevdataene som sendes til Brevserveren. Etter at brevet har blitt lagt på kø og håndtert videre av brevløsningen, returnerer brevserveren en kvitteringsmelding til bussen. Basert på status i kvitteringsmelding og journalpoststatus oppdateres så journalpoststatus i joark. Selve brevet blir lagret i journalposten av Brevserver.&lt;/p&gt;&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Figur 1: Aktivitetsdiagram for brevbestillingsprosessen&lt;/p&gt;&lt;p&gt;&lt;img src="file:/Z:/pjoark030.jpg"&gt;&lt;/img&gt;&lt;/p&gt;&lt;p&gt;1. Det gjøres en validering av inputdata for å sjekke om alle påkrevde felter er satt.&lt;/p&gt;&lt;p&gt;2. Brevdata hentes fra brevgruppe ihht. behandlingsregel 4.1.1.1.&lt;/p&gt;&lt;p&gt;3. Brevbestilling-objektet oppdateres med navn på brevmottaker fra output av Hent brevdata.&lt;/p&gt;&lt;p&gt;4. ESB3_2_007 kalles for å opprette journalpost.&lt;/p&gt;&lt;p&gt;5. ESB3_2_004 kalles for å hente OnDemandId fra den opprettede journalposten.&lt;/p&gt;&lt;p&gt;6. ESB3_3_002 kalles for å bestille brevet. Dersom kallet feiler skjer logikk i 4.1.1.2.&lt;/p&gt;&lt;h4&gt;Behandlingsregler&lt;/h4&gt;&lt;h5&gt;Logikk for valg av brevgruppe&lt;/h5&gt;&lt;p&gt;Ut i fra input BrevbestillingRequest.brevGruppe bestemmes hvilken brevgruppe som skal hentes fra baksystemet og sendes til Brevserveren.&lt;/p&gt;&lt;p&gt;HVIS brevGruppe = brevgr001&lt;br&gt;SÅ brukes SendPensjonStandardbrev&lt;/p&gt;&lt;p&gt;ELLER HVIS brevGruppe = brevgr002&lt;br&gt;SÅ brukes SendPensjonStandardVedtakPositivBrev&lt;/p&gt;&lt;p&gt;ELLER HVIS brevGruppe = brevgr003&lt;br&gt;SÅ brukes SendPensjonStandardVedtakNegativBrev&lt;/p&gt;&lt;p&gt;ELLER HVIS brevGruppe = brevgr004&lt;br&gt;SÅ brukes SendPensjonStandardVedtakAndre&lt;/p&gt;&lt;p&gt;ELLER HVIS brevGruppe = brevgr011&lt;br&gt;SÅ brukes SendStandardBrev&lt;/p&gt;&lt;p&gt;ELLER HVIS brevGruppe = brevgr007&lt;br&gt;SÅ brukes SendPensjonVedtakFleksibeltUttak&lt;/p&gt;&lt;h5&gt;Kompenserende logikk ved feil i DokBrev.SendBrev&lt;/h5&gt;&lt;p&gt;HVIS kall til DokBrev.SendBrev returnerer feil&lt;br&gt;SÅ skal ESB3_2_005 - Journal.LagreJournalpost kalles for å sette journalStatus til "A".&lt;/p&gt;&lt;h5&gt;Validering av input&lt;/h5&gt;&lt;p&gt;HVIS Sakskontekst.dokumenttype = ’N’ (notat)&lt;br&gt;&lt;/br&gt;OG Sakskontekst.kategori = ’SED’ (Strukturerte elektroniske dokumenter)&lt;br&gt;&lt;/br&gt;SÅ skal det ikke sjekkes om brukeren har adresse i TPS&lt;/p&gt;&lt;p&gt;&lt;/p&gt;&lt;p&gt;&lt;/p&gt; </wsdl:documentation>
+      <wsdl:input message="tns:bestillBrevRequest">
+    </wsdl:input>
+      <wsdl:output message="tns:bestillBrevResponse">
+    </wsdl:output>
+      <wsdl:fault name="henteBrevdataFeilet" message="tns:bestillBrev_henteBrevdataFeilet">
+    </wsdl:fault>
+      <wsdl:fault name="manglerObligatoriskInput" message="tns:bestillBrev_manglerObligatoriskInput">
+    </wsdl:fault>
+      <wsdl:fault name="opprettelseJournalpostFeilet" message="tns:bestillBrev_opprettelseJournalpostFeilet">
+    </wsdl:fault>
+      <wsdl:fault name="adresseIkkeRegistrert" message="tns:bestillBrev_adresseIkkeRegistrert">
+    </wsdl:fault>
+    </wsdl:operation>
+  </wsdl:portType>
+</wsdl:definitions>

--- a/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/arkiv/feil/feil.xsd
+++ b/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/arkiv/feil/feil.xsd
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema targetNamespace="http://nav.no/virksomhet/tjenester/arkiv/feil/v1" version="1.0" xmlns:feil="http://nav.no/virksomhet/tjenester/arkiv/feil/v1" xmlns:felles="http://nav.no/virksomhet/tjenester/felles/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:import namespace="http://nav.no/virksomhet/tjenester/felles/v1" schemaLocation="../../felles/felles.xsd"/>
+  <xsd:complexType name="AdresseIkkeRegistrert">
+    <xsd:annotation>
+      <xsd:documentation>&lt;p&gt;Kastes dersom bruker mangler adresse i TPS. (Fra SendPensjonStandardBrev)&lt;/p&gt;&lt;p&gt;NB: se behandlingsregel for validering av input&lt;/p&gt;</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="felles:StelvioFault"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="HenteBrevdataFeilet">
+    <xsd:annotation>
+      <xsd:documentation>&lt;p&gt;Kastes dersom hentBrevdata-tjenestene ikke returnerer alle påkrevde data for brev og journal.&lt;/p&gt;</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="felles:StelvioFault"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="ManglerObligatoriskInput">
+    <xsd:annotation>
+      <xsd:documentation>&lt;p&gt;Kastes dersom brevbestillingsrequesten mangler obligatorisk input.&lt;/p&gt;</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="felles:StelvioFault"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="OpprettelseJournalpostFeilet">
+    <xsd:annotation>
+      <xsd:documentation>&lt;p&gt;Kastes dersom noe går galt ved opprettelse av journalpost.&lt;/p&gt;</xsd:documentation>
+    </xsd:annotation>
+    <xsd:complexContent>
+      <xsd:extension base="felles:StelvioFault"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+</xsd:schema>

--- a/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/arkiv/feil/feil.xsd
+++ b/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/arkiv/feil/feil.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?><xsd:schema targetNamespace="http://nav.no/virksomhet/tjenester/arkiv/feil/v1" version="1.0" xmlns:feil="http://nav.no/virksomhet/tjenester/arkiv/feil/v1" xmlns:felles="http://nav.no/virksomhet/tjenester/felles/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <xsd:import namespace="http://nav.no/virksomhet/tjenester/felles/v1" schemaLocation="../../felles/felles.xsd"/>
+  <xsd:import namespace="http://nav.no/virksomhet/tjenester/felles/v1" schemaLocation="../../felles/felles-stelviofault.xsd"/>
   <xsd:complexType name="AdresseIkkeRegistrert">
     <xsd:annotation>
       <xsd:documentation>&lt;p&gt;Kastes dersom bruker mangler adresse i TPS. (Fra SendPensjonStandardBrev)&lt;/p&gt;&lt;p&gt;NB: se behandlingsregel for validering av input&lt;/p&gt;</xsd:documentation>

--- a/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/arkiv/meldinger/meldinger.xsd
+++ b/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/arkiv/meldinger/meldinger.xsd
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema targetNamespace="http://nav.no/virksomhet/tjenester/arkiv/meldinger/v1" version="1.0" xmlns:meldinger="http://nav.no/virksomhet/tjenester/arkiv/meldinger/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:complexType name="Attributt">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="verdi" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;F.eks fødselsnummer eller annet attributt til brevbestillingen (string)&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="typeKode" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Sier hva verdien er for noe. Gyldige koder:&lt;/p&gt;&lt;table border="1"&gt;&lt;col width="50.0%"&gt;&lt;/col&gt;&lt;col width="50.0%"&gt;&lt;/col&gt;&lt;tr&gt;&lt;td&gt;&lt;p&gt;&lt;b&gt;Kode&lt;/b&gt;&lt;/p&gt;&lt;/td&gt;&lt;td&gt;&lt;p&gt;&lt;b&gt;Beskrivelse&lt;/b&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;&lt;p&gt;AVDOD_FNR&lt;/p&gt;&lt;/td&gt;&lt;td&gt;&lt;p&gt;Avdødes fødselsnummer&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;p&gt;&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Vedlegg">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="nr" nillable="true" type="xsd:int"/>
+      <xsd:element minOccurs="0" name="innhold" type="xsd:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="Sakskontekst">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="saksid" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Unik identifikasjon av den aktuelle saken. Settes av konsument&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="saksbehandlernavn" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Navn på saksbehandler, settes av konsument&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="fagsystem" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Konsument Setter denne. Identifiserer kallende fagsystem&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="fagomradeKode" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Hvilket fagområde /tema journalposten tilhører.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="journalenhet" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Konsument setter denne. Enheten som behandler saken. &lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="dokumentdato" type="xsd:date">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Produksjonsdato på brevet. Settes av konsument. Systemdato kan brukes. &lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="gjelder" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Settes av konsument. Enten fødselsnummer eller TSS-id. Tilsvarer PSFnr_tssID tag i brevgruppe XML’er. &lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="dokumenttype" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Angir om dokumentet er 1) inngående 2) utgående 3) internt. Settes i Brevvalg. For batch er default verdi alltid 2). For PSAK er både valg 2 og 3 aktuelle.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="innhold" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Må oppgis ved andre journalstatuser enn M, U og A. Beskriver innhold i hoveddokumentet. Innholdsfeltet må brukes av alle, men verdier/ innholdet i feltet er fagspesifikt.  Ved fritekstbrev kan kategoriene f.eks være: Informasjon, vedtak, forespørsel. Dette feltet skal også benyttes til å angi beskrivelse av konverterte  grunnblanketter. Bidrag vil benytte dette feltet i stedet for sin gamle tjeneste. I BISYS  kalles dette feltet  ”Tjeneste”&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="kategori" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Angir kategori dokument. Settes av konsument.&lt;/p&gt;&lt;p&gt;B = Brev,&lt;/p&gt;&lt;p&gt;VB= Vedtaksbrev (brukes for å skille ut hva som skal sendes på nytt dersom brev ikke lest elektronisk)&lt;/p&gt;&lt;p&gt;IB = infobrev&lt;/p&gt;&lt;p&gt;ES = Elektronisk skjema,&lt;/p&gt;&lt;p&gt;TS = Tolkbart skjema&lt;/p&gt;&lt;p&gt;IS = Ikke tolkbart skjema&lt;/p&gt;&lt;p&gt;EP = e-post&lt;/p&gt;&lt;p&gt;F= Faktura&lt;/p&gt;&lt;p&gt;KS= Konverterte data fra gammelt system&lt;/p&gt;&lt;p&gt;KD= Konverterte dokumenter fra gammelt elektronisk arkiv&lt;/p&gt;&lt;p&gt;KM= Konvertert fra papirmappe (skannet)&lt;/p&gt;&lt;p&gt;SED=Strukturerte elektroniske dokumenter&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="mottaker" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Konsument setter denne. For Batch vil denne alltid være identisk med fnr/TSS-id i ”gjelder”. For PSAK vil denne kunne overstyres av enten fnr/ TSS-id til den som skal motta brevet. Tilsvarer Fnr_tssID2 i brevgruppe XML’er.&lt;/p&gt;&lt;p&gt;Mottaker er betinget obligatorisk, kun obligatorisk hvis dokumenttype N og kategori SED. Hvis dokumenttype = N eller kategori = SED skal ikke mottaker hentes inn og brev skal journalføres UTEN mottaker&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="sensitivitetsgrad" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Skal brukes av selvbetjeningsløsning for å bestemme om bruker kan se dokumentene. &lt;/p&gt;&lt;p&gt;Denne settes av konsument.&lt;/p&gt;&lt;p&gt;&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="kravtype" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Generisk felt på tvers av fagsystem. Kravtype kan være for eksempel søknad, klage, informasjon.  Begrepet kravtype kan brukes av alle, men verdier/ innholdet i feltet er fagspesifikt. Brukes ikke av pensjon.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="tilleggsbeskrivelse" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Evt. utfyllende beskrivelse av kravtype og tjeneste. Brukes ikke av pensjon.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="merknad" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Fritekstfelt for å legge inn kommentarer til dokumenthåndtering (Ikke saksbehandling). Krever regler for bruk i forhold til sensitive opplysninger, om feltet vil være tilgjengelig ved partsinnsyn osv. Brukes ikke av pensjon&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="fagspesifikkgradering" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Gradering for å styre tilgang for saksbehandlere (Eks: Farskapsdok har høy gradering). Feltet vil ikke brukes av pensjon.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="tillattelektroniskvarsling" nillable="true" type="xsd:boolean">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Om det kan gies varsling via kanal valgt av bruker i brukerprofil. Default verdi true/ja – for PSELV og GOSYS default false/nei.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="referanse" type="xsd:string"/>
+      <xsd:element minOccurs="0" name="vedlegg" type="meldinger:Vedlegg">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Kompleks type Vedlegg.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="land" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Land det har kommet blankett fra eller som det skal sendes blankett til. Kun e-blanketter som skal til og fra utenlandske myndigheter.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType name="BestillBrevRequest">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="brevKode" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Unik identifikasjon av brevtypen. &lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="brevGruppe" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Identifiserer brevgruppen, kodeverk utifra Brevkode&lt;/p&gt;&lt;table border="1"&gt;&lt;col width="50.0%"&gt;&lt;/col&gt;&lt;col width="50.0%"&gt;&lt;/col&gt;&lt;tr&gt;&lt;td&gt;&lt;p&gt;&lt;b&gt;brevGruppe&lt;/b&gt;&lt;/p&gt;&lt;/td&gt;&lt;td&gt;&lt;p&gt;&lt;b&gt;Beskrivelse&lt;/b&gt;&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;&lt;p&gt;brevgr001&lt;/p&gt;&lt;/td&gt;&lt;td&gt;&lt;p&gt;SendPensjonStandardbrev&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;&lt;p&gt;brevgr002&lt;/p&gt;&lt;/td&gt;&lt;td&gt;&lt;p&gt;SendPensjonStandardVedtakPositivBrev&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;&lt;p&gt;brevgr003&lt;/p&gt;&lt;/td&gt;&lt;td&gt;&lt;p&gt;SendPensjonStandardVedtakNegativBrev&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;&lt;p&gt;brevgr004&lt;/p&gt;&lt;/td&gt;&lt;td&gt;&lt;p&gt;SendPensjonStandardVedtakAndre&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;&lt;p&gt;brevgr007&lt;/p&gt;&lt;/td&gt;&lt;td&gt;&lt;p&gt;SendPensjonVedtakFleksibeltUttak&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;tr&gt;&lt;td&gt;&lt;p&gt;brevgr011&lt;/p&gt;&lt;/td&gt;&lt;td&gt;&lt;p&gt;SendStandardBrev&lt;/p&gt;&lt;/td&gt;&lt;/tr&gt;&lt;/table&gt;&lt;p&gt;&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="redigerbart" nillable="true" type="xsd:boolean">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Avgjør om brevet skal kunne redigeres. Populeres i Brevvalg utfra Brevkode&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="sprakKode" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Skal kun settes av konsument dersom konsument er PSAK og saksbehandler har overstyrt preferert språk i skjermbildet.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="vedtaksInformasjon" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;VedtaksId, obligatorisk for brevgruppene SendPensjonStandardVedtakNegativBrev og SendPensjonStandardVedtakPositiveBrev. Settes av konsument.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="soknadsInformasjon" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;KravId. Settes av konsument &lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element maxOccurs="unbounded" minOccurs="0" name="attributtListe" type="meldinger:Attributt">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Liste av kompleks type Attributt. Generell liste som kan inneholde f.eks avdødes fnr og andre relevante attributter til brevbestillingen.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="sakskontekst" type="meldinger:Sakskontekst">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Kompleks type Sakskontekst.&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="brevMottakerNavn" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Navn på mottaker. Brukes i tilfeller hvor Sakskontekst.dokumenttype = ’N’ og/eller Sakskontekst.kategori = ’SED’. Feltet skrives ellers over med uthentet data. &lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+  <xsd:complexType abstract="true" name="Utvidelse">
+    <xsd:sequence>
+      <xsd:any maxOccurs="unbounded" minOccurs="0" namespace="##any"/>
+    </xsd:sequence>
+    <xsd:anyAttribute namespace="##any"/>
+  </xsd:complexType>
+  <xsd:complexType name="BestillBrevUtvidelse1">
+    <xsd:complexContent>
+      <xsd:extension base="meldinger:Utvidelse"/>
+    </xsd:complexContent>
+  </xsd:complexType>
+  <xsd:complexType name="BestillBrevResponse">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="journalpostId" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;JournalpostId til det opprettede dokumentet&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element minOccurs="0" name="utvidelse" type="meldinger:BestillBrevUtvidelse1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>

--- a/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/arkiv/meldinger/meldinger.xsd
+++ b/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/arkiv/meldinger/meldinger.xsd
@@ -117,6 +117,11 @@
           <xsd:documentation>&lt;p&gt;Land det har kommet blankett fra eller som det skal sendes blankett til. Kun e-blanketter som skal til og fra utenlandske myndigheter.&lt;/p&gt;</xsd:documentation>
         </xsd:annotation>
       </xsd:element>
+      <xsd:element minOccurs="0" name="saksbehandlerId" type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>&lt;p&gt;Id på saksbehandler, settes av konsument. Innføres som en del av 2019-FL04&lt;/p&gt;</xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
     </xsd:sequence>
   </xsd:complexType>
   <xsd:complexType name="BestillBrevRequest">

--- a/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/felles/felles-stelviofault.xsd
+++ b/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/virksomhet/tjenester/felles/felles-stelviofault.xsd
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?><xsd:schema targetNamespace="http://nav.no/virksomhet/tjenester/felles/v1" version="1.0" xmlns:felles="http://nav.no/virksomhet/tjenester/felles/v1" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:complexType name="StelvioFault">
+    <xsd:sequence>
+      <xsd:element minOccurs="0" name="errorMessage" type="xsd:string"/>
+      <xsd:element minOccurs="0" name="errorSource" type="xsd:string"/>
+      <xsd:element minOccurs="0" name="errorType" type="xsd:string"/>
+      <xsd:element minOccurs="0" name="rootCause" type="xsd:string"/>
+      <xsd:element minOccurs="0" name="dateTimeStamp" type="xsd:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
Kan gjerne reviewe den siste commiten isolert, den første er bare en revert av tidligere commit.

1) fasit inneholdt WSDL med saksbehandlerid-feltet
2) renamet felles.xsd til felles-soapfault.xsd for fasit, siden den hadde annerledes innhold.