### PR TITLE
Legger til PPEN015 grensesnittet til SAM

### DIFF
--- a/pen-esb-wsclient-legacy/pom.xml
+++ b/pen-esb-wsclient-legacy/pom.xml
@@ -304,6 +304,19 @@
                                     </extraargs>
                                 </wsdlOption>
 
+                                <!-- SAM PPEN015 -->
+                                <wsdlOption>
+                                    <wsdl>${basedir}/src/main/resources/wsdl/nav-cons-sto-sam-ppen015_SAMPPEN015WSEXP.wsdl</wsdl>
+                                    <extraargs>
+                                        <extraarg>-p</extraarg>
+                                        <extraarg>http://nav-cons-sto-sam-ppen015/no/nav/inf/PPEN015=no.nav.inf.sam.ppen015</extraarg>
+                                        <extraarg>-p</extraarg>
+                                        <extraarg>http://nav-cons-sto-sam-ppen015/no/nav/inf/PPEN015/Binding=no.nav.inf.sam.ppen015</extraarg>
+                                        <extraarg>-p</extraarg>
+                                        <extraarg>http://nav-lib-cons-sto-sam/no/nav/lib/sto/sam/asbo/ppen015=no.nav.lib.sto.sam.asbo.ppen015</extraarg>
+                                    </extraargs>
+                                </wsdlOption>
+
                             </wsdlOptions>
                         </configuration>
                         <goals>

--- a/pen-esb-wsclient-legacy/src/main/resources/wsdl/nav-cons-sto-sam-ppen015_SAMPPEN015WSEXP.wsdl
+++ b/pen-esb-wsclient-legacy/src/main/resources/wsdl/nav-cons-sto-sam-ppen015_SAMPPEN015WSEXP.wsdl
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions name="SAMPPEN015WSEXP_SAMPPEN015Http_Service"
+                  targetNamespace="http://nav-cons-sto-sam-ppen015/no/nav/inf/PPEN015/Binding"
+                  xmlns:Port_0="http://nav-cons-sto-sam-ppen015/no/nav/inf/PPEN015"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:this="http://nav-cons-sto-sam-ppen015/no/nav/inf/PPEN015/Binding"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+
+    <wsdl:import location="no/nav/inf/SAMPPEN015.wsdl" namespace="http://nav-cons-sto-sam-ppen015/no/nav/inf/PPEN015"/>
+
+    <wsdl:binding name="SAMPPEN015WSEXP_SAMPPEN015HttpBinding" type="Port_0:SAMPPEN015">
+        <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="mottaSamhandlerSvar">
+            <soap:operation soapAction=""/>
+            <wsdl:input name="mottaSamhandlerSvarRequest">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="mottaSamhandlerSvarResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="SAMPPEN015WSEXP_SAMPPEN015HttpService">
+        <wsdl:port binding="this:SAMPPEN015WSEXP_SAMPPEN015HttpBinding" name="SAMPPEN015WSEXP_SAMPPEN015HttpPort">
+            <soap:address location="http://localhost:9080/nav-cons-sto-sam-ppen015Web/sca/SAMPPEN015WSEXP"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>

--- a/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/inf/SAMPPEN015.wsdl
+++ b/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/inf/SAMPPEN015.wsdl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:bons0="http://nav-lib-cons-sto-sam/no/nav/lib/sto/sam/asbo/ppen015"
+                  xmlns:tns="http://nav-cons-sto-sam-ppen015/no/nav/inf/PPEN015"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema" name="PPEN015"
+                  targetNamespace="http://nav-cons-sto-sam-ppen015/no/nav/inf/PPEN015">
+
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://nav-cons-sto-sam-ppen015/no/nav/inf/PPEN015"
+                    xmlns:bons0="http://nav-lib-cons-sto-sam/no/nav/lib/sto/sam/asbo/ppen015"
+                    xmlns:tns="http://nav-cons-sto-sam-ppen015/no/nav/inf/PPEN015"
+                    xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+            <xsd:import namespace="http://nav-lib-cons-sto-sam/no/nav/lib/sto/sam/asbo/ppen015"
+                        schemaLocation="../lib/sto/sam/asbo/ppen015/ASBOStoMottaSamhandlerSvarRequest.xsd"/>
+            <xsd:element name="mottaSamhandlerSvar">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="samhandlerSvarRequest" nillable="true"
+                                     type="bons0:ASBOStoMottaSamhandlerSvarRequest"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="mottaSamhandlerSvarResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="mottaSamhandlerSvarRequestMsg">
+        <wsdl:part element="tns:mottaSamhandlerSvar" name="mottaSamhandlerSvarParameters"/>
+    </wsdl:message>
+
+    <wsdl:message name="mottaSamhandlerSvarResponseMsg">
+        <wsdl:part element="tns:mottaSamhandlerSvarResponse" name="mottaSamhandlerSvarResult"/>
+    </wsdl:message>
+
+    <wsdl:portType name="SAMPPEN015">
+        <wsdl:operation name="mottaSamhandlerSvar">
+            <wsdl:input message="tns:mottaSamhandlerSvarRequestMsg" name="mottaSamhandlerSvarRequest"/>
+            <wsdl:output message="tns:mottaSamhandlerSvarResponseMsg" name="mottaSamhandlerSvarResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+</wsdl:definitions>

--- a/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/lib/sto/sam/asbo/ppen015/ASBOStoMottaSamhandlerSvarRequest.xsd
+++ b/pen-esb-wsclient-legacy/src/main/resources/wsdl/no/nav/lib/sto/sam/asbo/ppen015/ASBOStoMottaSamhandlerSvarRequest.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	targetNamespace="http://nav-lib-cons-sto-sam/no/nav/lib/sto/sam/asbo/ppen015">
+	<xsd:complexType name="ASBOStoMottaSamhandlerSvarRequest">
+		<xsd:sequence>
+			<xsd:element minOccurs="0" name="vedtaksId"
+				type="xsd:string" />
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
Denne pull requesten gjør SAM sitt grensesnitt for å kalle på [PPEN015 - Iverksett Vedtak](https://pensjon-esb-prosess-dokumentasjon.intern.dev.nav.no/ppen015/) tilgjengelig for PEN.

**Bakgrunn**

Vi starter snart flyttingen av prosessen PPEN015 fra bussen til pen. I en overgangsperiode så vil noen av iverksettingene være på bussen mens nye håndteres av ny behandlingsløsning. Dette kommer av at samhandlere kan bruke endel tid på å registrere informasjon påkrevd for å gjennomføre en iverksetting. Dokumentasjonen i [flytdiagrammet](https://pensjon-esb-prosess-dokumentasjon.intern.dev.nav.no/ppen015/EARoot/EA62.html) hevder at dette kan ta inntil 9 uker. Det er kun PEN som vet om en iverksetting er håndtert av buss eller av ny behandlingsløsning. Vi tenker derfor å endre på SAM og PEN slik at SAM kaller PEN vha REST og så tar PEN seg av kallet til bussen med SAM sitt gamle grensesnitt.

Endres fra
```mermaid
graph TD;
    Samhandler-->SAM;
    SAM-->|SAMPPEN015 SOAP API|BUSS;
```

Endres til

```mermaid
graph TD;
    Samhandler-->SAM;
    SAM-->|REST|PEN
    PEN-->|SAMPPEN015 SOAP API|BUSS;
```