### PR TITLE
Jakarta

### DIFF
--- a/.github/workflows/maven-build-package.yml
+++ b/.github/workflows/maven-build-package.yml
@@ -18,3 +18,18 @@ jobs:
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+
+  build-javax:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '8'
+
+    - name: Build with Maven
+      run: mvn -Pjavax -B package --file pom.xml

--- a/.github/workflows/maven-build-package.yml
+++ b/.github/workflows/maven-build-package.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: 8
+        java-version: '17'
         cache: 'maven'
 
     - name: Build with Maven

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: '17'
           cache: 'maven'
 
       - name: Package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,3 +28,25 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: .github/deploy.sh
+
+  release-javax:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: "read"
+      packages: "write"
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+
+      - name: Package
+        run: mvn -Pjavax verify -B --settings maven-settings-github.xml  -Dsurefire.rerunFailingTestsCount=3
+
+      - name: Deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: .github/deploy.sh

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,6 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
         <maven.min-version>3.6</maven.min-version>
         <revision>1.0.0-SNAPSHOT</revision>
     </properties>
@@ -64,21 +62,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <dependencies>
-        <dependency>
-            <groupId>jakarta.xml.bind</groupId>
-            <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>4.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.xml.ws</groupId>
-            <artifactId>jakarta.xml.ws-api</artifactId>
-            <version>4.0.1</version>
-            <scope>provided</scope>
-        </dependency>
-    </dependencies>
-
     <build>
         <pluginManagement>
             <plugins>
@@ -90,12 +73,12 @@
                 <plugin>
                     <groupId>org.apache.cxf</groupId>
                     <artifactId>cxf-codegen-plugin</artifactId>
-                    <version>4.0.3</version>
+                    <version>${cxf-codegen-plugin.version}</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.cxf.xjcplugins</groupId>
                             <artifactId>cxf-xjc-boolean</artifactId>
-                            <version>4.0.0</version>
+                            <version>${cxf-xjc-boolean.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -127,7 +110,7 @@
                             <rules>
                                 <requireJavaVersion>
                                     <message>Must use Java 17 when compiling</message>
-                                    <version>[17,18)</version>
+                                    <version>${required-java-version}</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>${maven.min-version}</version>
@@ -162,7 +145,62 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.3.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <classifier>${classifier}</classifier>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>javax</id>
+            <properties>
+                <classifier>javax</classifier>
+                <cxf-codegen-plugin.version>3.5.4</cxf-codegen-plugin.version>
+                <cxf-xjc-boolean.version>3.2.0</cxf-xjc-boolean.version>
+                <maven.compiler.target>1.8</maven.compiler.target>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <required-java-version>[1.8,1.9)</required-java-version>
+            </properties>
+        </profile>
+        <profile>
+            <id>jakarta</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <classifier>jakarta</classifier>
+                <cxf-codegen-plugin.version>4.0.3</cxf-codegen-plugin.version>
+                <cxf-xjc-boolean.version>4.0.0</cxf-xjc-boolean.version>
+                <maven.compiler.target>17</maven.compiler.target>
+                <maven.compiler.source>17</maven.compiler.source>
+                <required-java-version>[17,18)</required-java-version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>jakarta.xml.bind</groupId>
+                    <artifactId>jakarta.xml.bind-api</artifactId>
+                    <version>4.0.1</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>jakarta.xml.ws</groupId>
+                    <artifactId>jakarta.xml.ws-api</artifactId>
+                    <version>4.0.1</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
         <maven.min-version>3.6</maven.min-version>
         <revision>1.0.0-SNAPSHOT</revision>
     </properties>
@@ -64,6 +64,21 @@
         </dependencies>
     </dependencyManagement>
 
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.ws</groupId>
+            <artifactId>jakarta.xml.ws-api</artifactId>
+            <version>4.0.1</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <pluginManagement>
             <plugins>
@@ -75,12 +90,12 @@
                 <plugin>
                     <groupId>org.apache.cxf</groupId>
                     <artifactId>cxf-codegen-plugin</artifactId>
-                    <version>3.5.4</version>
+                    <version>4.0.3</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.cxf.xjcplugins</groupId>
                             <artifactId>cxf-xjc-boolean</artifactId>
-                            <version>3.2.0</version>
+                            <version>4.0.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -111,8 +126,8 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <message>Must use Java 1.8 when compiling</message>
-                                    <version>[1.8,1.9)</version>
+                                    <message>Must use Java 17 when compiling</message>
+                                    <version>[17,18)</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>${maven.min-version}</version>


### PR DESCRIPTION
Bygger pakker som kan brukes med både Spring Boot 2.7 (javax) og Spring Boot 3.0 (jakarta). Bruker classifier for å støtte det. Videre må man ta et bevist valg om man ønsker javax eller jakarta